### PR TITLE
Store category id rather than whole category in product.

### DIFF
--- a/lib/data.js
+++ b/lib/data.js
@@ -25,7 +25,7 @@ const products = Array(16).fill(true).map((v, i) => {
         description: faker.lorem.sentences(3),
         owner: faker.name.firstName() + " " + faker.name.lastName(),
         imageUrl: 'https://www.streamr.com/assets/HeroImages/Streamr-HeroImage.78f384ad8ae41942afb77cae2f199c80.jpg',
-        category: categories[i % categories.length],
+        category: categories[i % categories.length].id,
         streams: streamIds,
         previewStream: streamIds.length > 0 ? streamIds[0] : null,
         state: 'DEPLOYED',


### PR DESCRIPTION
`category` should supposedly be an id, rather than a `Category` object.

https://github.com/streamr-dev/marketplace/blob/master/src/flowtype/product-types.js#L22